### PR TITLE
feat: 支持通过快捷指令过滤剪贴板内容

### DIFF
--- a/Clipboard/Main/Model/TopBarViewModel.swift
+++ b/Clipboard/Main/Model/TopBarViewModel.swift
@@ -16,7 +16,7 @@ final class TopBarViewModel {
 
     var query: String = "" {
         didSet {
-            performSearch()
+            handleQueryChange()
         }
     }
 
@@ -689,6 +689,45 @@ final class TopBarViewModel {
     }
 
     // MARK: - Search Methods
+    
+    /// 处理查询变化，支持快捷指令（如 @img, @text 等）
+    private func handleQueryChange() {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespaces)
+        
+        // 检查是否是快捷指令
+        if trimmedQuery.hasPrefix("@") {
+            let command = String(trimmedQuery.dropFirst()).lowercased()
+            if let type = parseShortcutCommand(command) {
+                // 清空输入
+                query = ""
+                // 添加对应类型的过滤
+                toggleType(type)
+                return
+            }
+        }
+        
+        performSearch()
+    }
+    
+    /// 解析快捷指令
+    private func parseShortcutCommand(_ command: String) -> PasteModelType? {
+        switch command {
+        case "img", "image", "图片":
+            return .image
+        case "text", "txt", "文本":
+            return .string
+        case "file", "文件":
+            return .file
+        case "link", "链接":
+            return .link
+        case "color", "颜色":
+            return .color
+        case "rich", "富文本":
+            return .rich
+        default:
+            return nil
+        }
+    }
 
     private func performSearch() {
         searchTask?.cancel()


### PR DESCRIPTION
## 功能描述
新增快捷指令功能，支持在搜索框输入 `@` 开头的指令快速过滤剪贴板内容类型。

## 实现方式
- 在 `TopBarViewModel` 中添加 `handleQueryChange()` 方法，检测以 `@` 开头的输入
- 新增 `parseShortcutCommand()` 方法，解析快捷指令并映射到对应的 `PasteModelType`
- 输入快捷指令后自动转换为类型过滤标签

## 支持的快捷指令
- `@img` / `@image` / `@图片` → 过滤图片
- `@text` / `@txt` / `@文本` → 过滤文本
- `@file` / `@文件` → 过滤文件
- `@link` / `@链接` → 过滤链接
- `@color` / `@颜色` → 过滤颜色
- `@rich` / `@富文本` → 过滤富文本

## 测试
- [x] 在搜索框输入 `@img` 可以正确过滤图片
- [x] 支持中英文别名
- [x] 快捷指令输入后自动清空并添加对应的过滤标签

## 相关 Issue
https://github.com/Ineffable919/clipboard/issues/13